### PR TITLE
Fix a disk error

### DIFF
--- a/SwiftSemanticSearch/SearchModel.swift
+++ b/SwiftSemanticSearch/SearchModel.swift
@@ -274,6 +274,9 @@ actor ImageIndexActor {
         rows: UInt32,
         columns: UInt32
     ) async throws {
+        let documentsDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        let indexPathForSave = documentsDirectory.appendingPathComponent("images.uform3-image-text-english-small.usearch")
+
         let indexPath = Bundle.main.resourcePath!.appending("/images.uform3-image-text-english-small.usearch")
         let indexURL = URL(fileURLWithPath: indexPath)
         
@@ -296,7 +299,7 @@ actor ImageIndexActor {
                 let _ = imageIndex.add(key: UInt64(row), vector: matrix[range])
             }
             
-            imageIndex.save(path: indexPath)
+            imageIndex.save(path: indexPathForSave.path)
         }
         
         searchModel.imageIndex = imageIndex


### PR DESCRIPTION
- Fix the issue: [#4](https://github.com/ashvardanian/SwiftSemanticSearch/issues/4)
- The issue seems to be caused by trying to write the index to `Bundle.main.resourcePath`, which is read-only.
- So I fetched a new path from the document directory and updated it to write the index there.