### PR TITLE
Fix a crash when searching after loading an index file

### DIFF
--- a/SwiftSemanticSearch/SearchModel.swift
+++ b/SwiftSemanticSearch/SearchModel.swift
@@ -288,8 +288,15 @@ actor ImageIndexActor {
         )
         
         if FileManager.default.fileExists(at: indexURL) {
+            print("Bundle index found. Load index from bundle file")
             imageIndex.load(path: indexPath)
-        } else {
+        }
+        else if FileManager.default.fileExists(at: indexPathForSave) {
+            print("Saved index found. Load index from saved index file")
+            imageIndex.load(path: indexPathForSave.path)
+        }
+        else {
+            print("No bundle or saved index found. Build index and save it.")
             let _ = imageIndex.reserve(rows)
             
             let columns = Int(columns)

--- a/SwiftSemanticSearch/SearchModel.swift
+++ b/SwiftSemanticSearch/SearchModel.swift
@@ -180,6 +180,7 @@ class SearchModel: ObservableObject {
         do {
             // Get the embedding for the query.
             let queryEmbedding = try textEncoder.encode(query).asFloats()
+            imageIndex.reserve(100)
             let results = imageIndex.search(vector: queryEmbedding, count: 100)
             
             await Task.yield()


### PR DESCRIPTION
- Fix the issue: #8 
  - As @ashvardanian mentioned in the above issue, a call of `reverse` is needed before `search`
  - This issue happens both for the saved index file and the bundled index file (`images.uform3-image-text-english-small.usearch`)
- Reuse a previously saved index file, if it exists.